### PR TITLE
Fixed dynamic linker errors when loading this plugin

### DIFF
--- a/rtt_gazebo_plugin/CMakeLists.txt
+++ b/rtt_gazebo_plugin/CMakeLists.txt
@@ -37,12 +37,13 @@ add_library(${PROJECT_NAME} src/rtt_plugin.cpp)
 set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS -DRTT_STATIC)
 target_link_libraries(${PROJECT_NAME}
   ${GAZEBO_LIBRARIES}
-  ${catkin_LIBRARIES} 
-  ${OROCOS-RTT_LIBRARIES}
+  ${catkin_LIBRARIES}
+  ${OROCOS-RTT_LIBRARIES} ${OROCOS-RTT_RTT-SCRIPTING_LIBRARY} ${OROCOS-RTT_RTT-TRANSPORT-CORBA_LIBRARY}
+  ${USE_OROCOS_LIBRARIES}
   boost_thread
   orocos-kdl)
 
-set(CMAKE_BUILD_TYPE Debug)
+#set(CMAKE_BUILD_TYPE Debug)
 
 ## Default component
 orocos_component(default_gazebo_component src/default_gazebo_component.cpp)


### PR DESCRIPTION
I tried to use the rtt_gazebo_plugin and got the following error when I loaded a model in gazebo:

```
Error [Plugin.hh:127] Failed to load plugin librtt_gazebo_plugin.so: undefined symbol: _ZN11omni_thread6init_tD1Ev
```

I added a few more elements to the target_link_libraries() line in rtt_gazebo_plugin's `CMakeLists.txt` and the error vanished. Especially the `${USE_OROCOS_LIBRARIES}` part was missing after auto-linking has been disabled for catkin. Also note that `${OROCOS-RTT_LIBRARIES}` does not automatically aggregate all components mentioned in `find_package(OROCOS-RTT)`.

I am not sure if explicit linking to the rtt-transport-corba plugin is really required here. The missing symbol is defined in the orocos-rtt-corba library and its dependencies which is linked via the `orocos_use_package()` mechanism. At least the gazebo plugin can be compiled and loaded successfully without adding ´${OROCOS-RTT_RTT-TRANSPORT-CORBA_LIBRARY}´ to the linked libraries.
