### PR TITLE
Removed ocl orocos packages from dependencies in package.xml files

### DIFF
--- a/rtt_gazebo_console/package.xml
+++ b/rtt_gazebo_console/package.xml
@@ -13,9 +13,6 @@
 
   <build_depend>rtt</build_depend>
   <build_depend>ocl</build_depend>
-  <build_depend>ocl-deployment</build_depend>
-  <build_depend>ocl-taskbrowser</build_depend>
-  <build_depend>ocl-logging</build_depend>
 
   <export>
   </export>

--- a/rtt_gazebo_plugin/package.xml
+++ b/rtt_gazebo_plugin/package.xml
@@ -11,7 +11,6 @@
 
   <build_depend>rtt</build_depend>
   <build_depend>ocl</build_depend>
-  <build_depend>ocl-deployment</build_depend>
   <build_depend>gazebo</build_depend>
 
   <run_depend>gazebo</run_depend>


### PR DESCRIPTION
... as they produce rosdep errors. ocl as a package name is sufficient here.
