### PR TITLE
Removed find_package(Orocos-KDL REQUIRED) from rtt_gazebo_activity/CMakeLists.txt

### DIFF
--- a/rtt_gazebo_activity/CMakeLists.txt
+++ b/rtt_gazebo_activity/CMakeLists.txt
@@ -10,8 +10,6 @@ find_package(catkin REQUIRED COMPONENTS roscpp)
 find_package(OROCOS-RTT REQUIRED)
 include(${OROCOS-RTT_USE_FILE_PATH}/UseOROCOS-RTT.cmake )
 
-find_package(orocos_kdl REQUIRED)
-
 ###################################
 ## catkin specific configuration ##
 ###################################
@@ -33,7 +31,6 @@ catkin_package(
 include_directories(
   include
   ${catkin_INCLUDE_DIRS}
-  ${orocos_kdl_INCLUDE_DIRS}
 )
 
 orocos_library(rtt_gazebo_activity src/gazebo_activity.cpp)


### PR DESCRIPTION
... as KDL is not used in rtt_gazebo_activity.

These lines have been added during the merge in https://github.com/jhu-lcsr/rtt_gazebo/commit/f3b99b76a1404b46ea66bd15f0dd02e5e7b25fba.
