### PR TITLE
Add script option to deployer

### DIFF
--- a/rtt_gazebo_console/CMakeLists.txt
+++ b/rtt_gazebo_console/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(OROCOS-RTT REQUIRED COMPONENTS
   rtt-scripting 
   rtt-transport-corba)
 
+find_package(Boost REQUIRED COMPONENTS program_options)
 include(${OROCOS-RTT_USE_FILE_PATH}/UseOROCOS-RTT.cmake )
 
 include_directories(
@@ -21,7 +22,7 @@ orocos_use_package( orocos-rtt-corba )
 
 add_definitions(-DRTT_STATIC)
 orocos_executable(console src/console.cpp)
-target_link_libraries(console ${USE_OROCOS_LIBRARIES})
+target_link_libraries(console ${USE_OROCOS_LIBRARIES} ${Boost_LIBRARIES})
 
 orocos_generate_package()
 

--- a/rtt_gazebo_console/src/console.cpp
+++ b/rtt_gazebo_console/src/console.cpp
@@ -8,20 +8,35 @@
 
 #include <ocl/TaskBrowser.hpp>
 #include <rtt/os/main.h>
+#include <boost/program_options.hpp>
 
 using namespace RTT::corba;
 using namespace RTT;
+namespace po = boost::program_options;
 
 int ORO_main(int argc, char** argv)
 {
+  // Add parser for program options
+  po::options_description description("RTT Gazebo Console Usage");
+  description.add_options()
+    ("help,h", "Display this help message")
+    ("script,s",po::value<std::string>(), "Run an ops script");
+    
+  po::variables_map vm;
+  po::store(po::command_line_parser(argc, argv).options(description).run(), vm);
+  po::notify(vm);
+  
   // Setup Corba:
   TaskContextProxy::InitOrb(argc, argv);
 
   // Get a pointer to the component above
   OCL::CorbaDeploymentComponent console_deployer("console_deployer");
   console_deployer.loadComponent("gazebo","CORBA");
-  console_deployer.import("kdl_typekit");
-
+  
+  // Run an ops script if option is provided
+  if(vm.count("script"))
+      console_deployer.runScript(vm["script"].as<std::string>());
+  
   // Interface it:
   OCL::TaskBrowser browse( &console_deployer );
   browse.loop();


### PR DESCRIPTION
This add the "-s" option to the console using boost::program_option : 
```
rosrun rtt_gazebo_console console -s /my/script.ops
```
This console seems to somehow close more properly the connection than deployer-corba.