### PR TITLE
Gazebo 6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: required
+
 language:
   - cpp
   - python

--- a/rtt_gazebo_console/CMakeLists.txt
+++ b/rtt_gazebo_console/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rtt_gazebo_console)
-
+list(APPEND CMAKE_CXX_FLAGS "-std=c++11")
 find_package(catkin REQUIRED)
 
 find_package(OROCOS-RTT REQUIRED COMPONENTS 

--- a/rtt_gazebo_console/CMakeLists.txt
+++ b/rtt_gazebo_console/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rtt_gazebo_console)
-list(APPEND CMAKE_CXX_FLAGS "-std=c++11")
 find_package(catkin REQUIRED)
 
 find_package(OROCOS-RTT REQUIRED COMPONENTS 

--- a/rtt_gazebo_deployer/CMakeLists.txt
+++ b/rtt_gazebo_deployer/CMakeLists.txt
@@ -11,6 +11,11 @@ include(${OROCOS-RTT_USE_FILE_PATH}/UseOROCOS-RTT.cmake )
 
 find_package(gazebo REQUIRED)
 
+# Add c++11 for Gazebo >= 6.0
+if(${GAZEBO_VERSION} GREATER 6)
+list(APPEND CMAKE_CXX_FLAGS "-std=c++11")
+endif()
+
 find_package(Eigen REQUIRED)
 find_package(Boost COMPONENTS thread REQUIRED)
 

--- a/rtt_gazebo_deployer/CMakeLists.txt
+++ b/rtt_gazebo_deployer/CMakeLists.txt
@@ -11,8 +11,10 @@ include(${OROCOS-RTT_USE_FILE_PATH}/UseOROCOS-RTT.cmake )
 find_package(gazebo REQUIRED)
 
 # Add c++11 for Gazebo >= 6.0
-if(${GAZEBO_VERSION} GREATER 6)
-list(APPEND CMAKE_CXX_FLAGS "-std=c++11")
+if(${GAZEBO_VERSION})
+  if(${GAZEBO_VERSION} GREATER 6)
+    list(APPEND CMAKE_CXX_FLAGS "-std=c++11")
+  endif()
 endif()
 
 find_package(Eigen REQUIRED)

--- a/rtt_gazebo_deployer/CMakeLists.txt
+++ b/rtt_gazebo_deployer/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rtt_gazebo_deployer)
-list(APPEND CMAKE_CXX_FLAGS "-std=c++11")
 ## Find catkin macros and  braries
 find_package(catkin REQUIRED COMPONENTS 
   cmake_modules)

--- a/rtt_gazebo_deployer/CMakeLists.txt
+++ b/rtt_gazebo_deployer/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rtt_gazebo_deployer)
-
+list(APPEND CMAKE_CXX_FLAGS "-std=c++11")
 ## Find catkin macros and  braries
 find_package(catkin REQUIRED COMPONENTS 
   cmake_modules)

--- a/rtt_gazebo_examples/CMakeLists.txt
+++ b/rtt_gazebo_examples/CMakeLists.txt
@@ -8,8 +8,10 @@ find_package(catkin REQUIRED COMPONENTS rtt_ros cmake_modules)
 find_package(gazebo REQUIRED)
 
 # Add c++11 for Gazebo >= 6.0
-if(${GAZEBO_VERSION} GREATER 6)
-list(APPEND CMAKE_CXX_FLAGS "-std=c++11")
+if(${GAZEBO_VERSION})
+  if(${GAZEBO_VERSION} GREATER 6)
+    list(APPEND CMAKE_CXX_FLAGS "-std=c++11")
+  endif()
 endif()
 
 find_package(OROCOS-RTT REQUIRED COMPONENTS rtt-scripting rtt-transport-corba)

--- a/rtt_gazebo_examples/CMakeLists.txt
+++ b/rtt_gazebo_examples/CMakeLists.txt
@@ -1,12 +1,17 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rtt_gazebo_examples)
-list(APPEND CMAKE_CXX_FLAGS "-std=c++11")
 ## Find catkin macros and libraries
 find_package(catkin REQUIRED COMPONENTS rtt_ros cmake_modules)
 
 
 # Depend on system install of Gazebo 
 find_package(gazebo REQUIRED)
+
+# Add c++11 for Gazebo >= 6.0
+if(${GAZEBO_VERSION} GREATER 6)
+list(APPEND CMAKE_CXX_FLAGS "-std=c++11")
+endif()
+
 find_package(OROCOS-RTT REQUIRED COMPONENTS rtt-scripting rtt-transport-corba)
 include(${OROCOS-RTT_USE_FILE_PATH}/UseOROCOS-RTT.cmake )
 find_package(orocos_kdl REQUIRED)

--- a/rtt_gazebo_examples/CMakeLists.txt
+++ b/rtt_gazebo_examples/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rtt_gazebo_examples)
-
+list(APPEND CMAKE_CXX_FLAGS "-std=c++11")
 ## Find catkin macros and libraries
 find_package(catkin REQUIRED COMPONENTS rtt_ros cmake_modules)
 

--- a/rtt_gazebo_system/CMakeLists.txt
+++ b/rtt_gazebo_system/CMakeLists.txt
@@ -9,8 +9,10 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(gazebo REQUIRED)
 
 # Add c++11 for Gazebo >= 6.0
-if(${GAZEBO_VERSION} GREATER 6)
-list(APPEND CMAKE_CXX_FLAGS "-std=c++11")
+if(${GAZEBO_VERSION})
+  if(${GAZEBO_VERSION} GREATER 6)
+    list(APPEND CMAKE_CXX_FLAGS "-std=c++11")
+  endif()
 endif()
 
 find_package(OROCOS-RTT REQUIRED COMPONENTS rtt-scripting rtt-transport-corba)

--- a/rtt_gazebo_system/CMakeLists.txt
+++ b/rtt_gazebo_system/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rtt_gazebo_system)
-list(APPEND CMAKE_CXX_FLAGS "-std=c++11")
 ## Find catkin macros and libraries
 find_package(catkin REQUIRED COMPONENTS
   cmake_modules)
@@ -8,6 +7,12 @@ find_package(catkin REQUIRED COMPONENTS
 
 # Depend on system install of Gazebo 
 find_package(gazebo REQUIRED)
+
+# Add c++11 for Gazebo >= 6.0
+if(${GAZEBO_VERSION} GREATER 6)
+list(APPEND CMAKE_CXX_FLAGS "-std=c++11")
+endif()
+
 find_package(OROCOS-RTT REQUIRED COMPONENTS rtt-scripting rtt-transport-corba)
 include(${OROCOS-RTT_USE_FILE_PATH}/UseOROCOS-RTT.cmake )
 find_package(orocos_kdl REQUIRED)

--- a/rtt_gazebo_system/CMakeLists.txt
+++ b/rtt_gazebo_system/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rtt_gazebo_system)
-
+list(APPEND CMAKE_CXX_FLAGS "-std=c++11")
 ## Find catkin macros and libraries
 find_package(catkin REQUIRED COMPONENTS
   cmake_modules)

--- a/rtt_gazebo_system/src/rtt_system_plugin.cpp
+++ b/rtt_gazebo_system/src/rtt_system_plugin.cpp
@@ -25,8 +25,11 @@
 
 // RTT/ROS Simulation Clock Activity
 #include <rtt_rosclock/rtt_rosclock.h>
+
+#ifdef RTT_GAZEBO_DEBUG
 #include <rtt_rosclock/prof.h>
 #include <rtt_rosclock/throttle.h>
+#endif
 
 #include "rtt_system_plugin.h"
 


### PR DESCRIPTION
This only adds c++11 flags if gazebo >= 6 . There should be a better way to add them.
A few warnings for deprecated functions pops up but it's working flawlessly.
